### PR TITLE
Adds Cmake build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ doxygen
 *~
 platform_folders
 nbproject
+
+# Commonly used build dir
+build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,34 @@
 language: cpp
-
-os:
-  - linux
-  - osx
-
-compiler:
-  - gcc
-  - clang
-script: make && ./platform_folders.out
-
+matrix:
+  include:
+    - os: linux
+      env: BUILD_TYPE=Debug
+      compiler: gcc
+    - os: linux
+      env: BUILD_TYPE=Debug
+      compiler: clang
+    - os: linux
+      env: BUILD_TYPE=Release
+      compiler: gcc
+    - os: linux
+      env: BUILD_TYPE=Release
+      compiler: clang
+    - os: osx
+      env: BUILD_TYPE=Debug
+      compiler: gcc
+    - os: osx
+      env: BUILD_TYPE=Debug
+      compiler: clang
+    - os: osx
+      env: BUILD_TYPE=Release
+      compiler: gcc
+    - os: osx
+      env: BUILD_TYPE=Release
+      compiler: clang
+before_script:
+  - mkdir -p build && cd build
+script:
+  # Run cmake, then compile and run tests with make
+  - cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE .. && make -j$(nproc) && make test
 notifications:
   email: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,118 @@
+cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
+project(platform_folders VERSION 3.0.0 LANGUAGES CXX)
+
+# Since it's off, the library will be static by default
+option(BUILD_SHARED_LIBS "Build shared instead of static." OFF)
+
+add_library(${PROJECT_NAME}
+	sago/platform_folders.cpp
+)
+
+# Where to search for the header
+# The BUILD/INSTALL interface expressions are for exporting
+target_include_directories(${PROJECT_NAME} PRIVATE
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/sago>
+	$<INSTALL_INTERFACE:sago>
+)
+
+# Define the header as public for installation
+set_target_properties(${PROJECT_NAME} PROPERTIES
+	PUBLIC_HEADER "sago/platform_folders.h"
+)
+
+# Apple requires linking to CoreServices
+# Check sys name instead of "APPLE" for cross-compilation
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+	# Find the framework
+	# ref: https://developer.apple.com/library/content/documentation/MacOSX/Conceptual/OSX_Technology_Overview/SystemFrameworks/SystemFrameworks.html
+	find_library(_CoreServices_FRAMEWORK
+		NAMES "CoreServices.framework" "CoreServices"
+		PATH_SUFFIXES "CoreServices"
+		PATHS "/System/Library/Frameworks"
+	)
+	# Make sure it was found
+	if(NOT _CoreServices_FRAMEWORK)
+		message(FATAL_ERROR "Could not find the CoreServices framework!")
+	endif()
+	# Link to the CoreServices framework. This also sets the correct linking options
+	# "If the library file is in a Mac OSX framework, the Headers directory of the framework will also be processed as a usage requirement."
+	target_link_libraries(${PROJECT_NAME} PRIVATE "${_CoreServices_FRAMEWORK}")
+endif()
+
+# Defines standardized defaults for install paths
+include(GNUInstallDirs)
+# For the config and configversion macros
+include(CMakePackageConfigHelpers)
+
+# Controls what dir to prefix for the lib, so <sago/platform_folders.h>
+set(_PROJECT_INSTALL_PREFIX_DIR "sago")
+# Controls where the exports, config, and configversion files install to
+set(_PROJECT_INSTALL_CMAKE_DIR "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/${_PROJECT_INSTALL_PREFIX_DIR}")
+
+# Gives "Make install" esque operations a location to install to...
+# and creates a .cmake file to be exported
+install(TARGETS ${PROJECT_NAME}
+	EXPORT "${PROJECT_NAME}-targets"
+	LIBRARY DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/${_PROJECT_INSTALL_PREFIX_DIR}"
+	ARCHIVE DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/${_PROJECT_INSTALL_PREFIX_DIR}"
+	# Tells it where to put your headers if any set by set_target_properties
+	PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_FULL_INCLUDEDIR}/${_PROJECT_INSTALL_PREFIX_DIR}"
+	# Tells export where your includes folder is | Note that the private include path is not needed here
+	INCLUDES DESTINATION "${CMAKE_INSTALL_FULL_INCLUDEDIR}/${_PROJECT_INSTALL_PREFIX_DIR}"
+)
+
+# "The install(TARGETS) and install(EXPORT) commands work together to install a target and a file to help import it"
+# Installs a cmake file which external projects can import.
+install(EXPORT "${PROJECT_NAME}-targets"
+	DESTINATION "${_PROJECT_INSTALL_CMAKE_DIR}"
+)
+
+# "The export command is used to generate a file exporting targets from a project build tree"
+# Creates an import file for external projects which are aware of the build tree.
+# May be useful for cross-compiling
+export(TARGETS ${PROJECT_NAME}
+	FILE "${PROJECT_NAME}-exports.cmake"
+)
+
+configure_package_config_file("${PROJECT_NAME}Config.cmake.in"
+	"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+	# Tells the config file where it will be installed, so it can be correctly imported
+	INSTALL_DESTINATION "${_PROJECT_INSTALL_CMAKE_DIR}"
+	# This passes the variables to the cmake.in file, which uses them
+	PATH_VARS PROJECT_NAME
+)
+
+# Creates the project's ConfigVersion.cmake file
+# This allows for find_package() to use a version in the call
+write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+	# This'll require versioning in the project() call
+	VERSION ${CMAKE_PROJECT_VERSION}
+	# Just assuming Semver is followed
+	COMPATIBILITY SameMajorVersion
+)
+
+# Install the ConfigVersion file, which is located in the build dir
+install(FILES
+		"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+		"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+	DESTINATION "${_PROJECT_INSTALL_CMAKE_DIR}"
+)
+
+# A module for testing the library
+include(CTest)
+# BUILD_TESTING is defined (default ON) in CTest
+if(BUILD_TESTING)
+	set(_PROJECT_TEST_NAME "${PROJECT_NAME}_test")
+	add_executable(${_PROJECT_TEST_NAME} platform_folders.cpp)
+
+	target_link_libraries(${_PROJECT_TEST_NAME} PRIVATE ${PROJECT_NAME})
+
+	# Since tests aren't installed, no reason to give it an INSTALL_INTERFACE
+	target_include_directories(${_PROJECT_TEST_NAME} PRIVATE
+		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/sago>
+	)
+
+	# Creates the "MyTest" test that runs the test executable created above
+	# This is triggered by things like "make test"
+	add_test(NAME MyTest COMMAND ${_PROJECT_TEST_NAME})
+endif()

--- a/platform_foldersConfig.cmake.in
+++ b/platform_foldersConfig.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")


### PR DESCRIPTION
I've tested on Linux, and can correctly build (`cmake .. && make`), install (`make install`), and run tests (`make test`).

The library is installed to the system's libpath (ex: `/usr/local/lib/sago/libplatform_folders.a`)
The header is installed to the system's includepath (ex `/usr/local/include/sago/platform_folders.h`)

Other projects can also use Cmake's `find_package()` to find `platform_folders`.
I assumed you follow Semver, and set the compatibility to `SameMajorVersion`, which takes effect when someone runs `find_package()` with a required version.

Hopefully I edited the `.travis.yml` correctly, but I might've messed that up.

edit: Seems I missed some `-framework` thing for macOS? Not sure..