### PR TITLE
Adds AppVeyor CI support (Windows)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,78 @@
+# Notes:
+#   - Minimal appveyor.yml file is an empty file. All sections are optional.
+#   - Indent each level of configuration with 2 spaces. Do not use tabs!
+#   - All section names are case-sensitive.
+#   - Section names should be unique on each level.
+
+#---------------------------------#
+#      general configuration      #
+#---------------------------------#
+
+# version format
+version: '{branch}-{build}'
+
+# branches to build
+branches:
+  # blacklist
+  except:
+    - gh-pages
+
+#---------------------------------#
+#    environment configuration    #
+#---------------------------------#
+
+image:
+  - Visual Studio 2015
+  - Visual Studio 2017
+
+# build Configuration, i.e. Debug, Release, etc.
+configuration:
+  - Debug
+  - Release
+
+platform:
+  - x86
+  - x64
+
+# clone directory
+clone_folder: c:\projects\platform_folders
+
+# This and clone_depth speed up git cloning
+# fetch repository as zip archive
+shallow_clone: true
+
+# set clone depth
+clone_depth: 1
+
+# Generate the .sln file with Cmake before running MSBuild
+before_build:
+  - cmd: mkdir c:\projects\platform_folders\build
+  - cmd: cd c:\projects\platform_folders\build
+  # I know this is ugly, but the matrix didn't work, and newlines seem to not be supported
+  - cmd: IF %APPVEYOR_BUILD_WORKER_IMAGE%=="Visual Studio 2015" (IF %PLATFORM%=="x86" (cmake -G "Visual Studio 14 2015" ..) ELSE (cmake -G "Visual Studio 14 2015 Win64" -T host=x64 ..)) ELSE (IF %PLATFORM%=="x86" (cmake -G "Visual Studio 15 2017" ..) ELSE (cmake -G "Visual Studio 15 2017 Win64" -T host=x64 ..))
+
+# Runs MSBuild.exe with logging & some options
+build:
+  # Allows for faster builds
+  parallel: true
+  # The solution file is the name of the project() given to Cmake
+  project: platform_folders.sln
+  # Trust me, you don't want higher than minimal. Even this is spammy
+  verbosity: minimal
+
+#---------------------------------#
+#       tests configuration       #
+#---------------------------------#
+
+# to run your custom scripts instead of automatic tests
+# The %CONFIGURATION% and %PLATFORM% variables are set from Appveyor as env-vars
+test_script:
+  - cmd: MSBuild.exe /p:Configuration=%CONFIGURATION% /p:Platform=%PLATFORM% /v:minimal RUN_TESTS.vcxproj
+
+#---------------------------------#
+#        global handlers          #
+#---------------------------------#
+
+# on build failure dump cmake err log
+on_failure:
+  - cmd: type c:\projects\platform_folders\build\CMakeFiles\CMakeError.log


### PR DESCRIPTION
Tested valid on https://ci.appveyor.com/tools/validate-yaml

This should create a matrix of builds like so:

* VS 2015
  * 32-bit
    * Debug
    * Release
  * 64-bit
    * Debug
    * Release
* VS 2017
  * 32-bit
    * Debug
    * Release
  * 64-bit
    * Debug
    * Release

I tried to make it cleaner using their actual `matrix` keyword, but it's not flexible enough to do the job.

---

**Note:** you'll have to link Appveyor to this repo.