### PR TITLE
Fix for Linux cache dir

### DIFF
--- a/sago/platform_folders.cpp
+++ b/sago/platform_folders.cpp
@@ -203,7 +203,7 @@ std::string getCacheDir() {
 #elif defined(__APPLE__)
 	return GetMacFolder(kCachedDataFolderType, "Failed to find the Application Support Folder");
 #else
-	return getLinuxFolderDefault("XDG_CONFIG_HOME", ".cache");
+	return getLinuxFolderDefault("XDG_CACHE_HOME", ".cache");
 #endif
 }
 


### PR DESCRIPTION
Original source code does not display true cache directory on Ubuntu.
I changed the environmental variable used for system cache dir, from XDG_CONFIG_HOME to XDG_CACHE_HOME and this problem disappeared.