### PR TITLE
XDG_ dirs check

### DIFF
--- a/sago/platform_folders.cpp
+++ b/sago/platform_folders.cpp
@@ -253,13 +253,20 @@ static void PlatformFoldersAddFromFile(const std::string& filename, std::map<std
 	std::ifstream infile(filename.c_str());
 	std::string line;
 	while (std::getline(infile, line)) {
-		if (line.length() == 0 || line.at(0) == '#') {
+		if (line.length() == 0 || line.at(0) == '#' || line.substr(0, 4) != "XDG_" || line.find("_DIR") == std::string::npos) {
 			continue;
 		}
-		std::size_t splitPos = line.find("=");
-		std::string key = line.substr(0, splitPos);
-		std::string value = line.substr(splitPos+2, line.length()-splitPos-3);
-		folders[key] = value;
+		try {
+			std::size_t splitPos = line.find('=');
+			std::string key = line.substr(0, splitPos);
+			std::size_t valueStart = line.find('"', splitPos);
+			std::size_t valueEnd = line.find('"', valueStart+1);
+			std::string value = line.substr(valueStart+1, valueEnd - valueStart - 1);
+			folders[key] = value;
+		} catch (std::exception&  e) {
+			std::cerr << "WARNING: Failed to process \"" << line << "\" from \"" << filename << "\". Error: "<< e.what() << "\n";
+			continue;
+		}
 	}
 }
 


### PR DESCRIPTION
Current implementation can fail if the user-dirs.dirs-file contain a property line without values like:
`HELLO=`
At the moment this is not valid but the XDG specification may be updated and regardless, we should not handle it the way we do.

This ensures that we do only look at properties that start with "XDG_" and contains "_DIR". 

The check is very basic. I had to drop regex. gcc does not support it until 4.9. Current oldest target is 4.8.4 (Ubuntu 14.04)