### PR TITLE
Debug library suffix d, so we can easily install both to be used with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ add_library(platform_folders
 	sago/platform_folders.cpp
 )
 
+set_target_properties(platform_folders PROPERTIES DEBUG_POSTFIX d)
+
 # Creates an alias so that people building in-tree (instead of using find_package)...
 # can still link against the same target
 add_library(sago::platform_folders ALIAS platform_folders)


### PR DESCRIPTION
With visual studio, many libraries use d suffix. This way, we can install both debug and release version into the same folder.

If you think that this change will break backwards compatibility for the users (it shouldn't - if they use as a part of cmake project, it will silently change this, reconfigure in VS and keep working with new library name), comment on this, I can add some kind of cmake boolean to control if we want to use same or different name.

Example result for one of my projects (after using cmake install on dependencies):
```
>dir
 # <private info deleted >
03/12/2019  05:19    <DIR>          .
03/12/2019  05:19    <DIR>          ..
03/12/2019  05:18    <DIR>          cmake
03/12/2019  05:18         1.333.574 fmt.lib
03/12/2019  05:19         4.135.034 fmtd.lib
03/12/2019  05:18    <DIR>          pkgconfig
02/12/2019  22:21           116.778 platform_folders.lib
02/12/2019  22:21           383.652 platform_foldersd.lib
```