### PR TITLE
Fix Windows UTF conversion exception message

### DIFF
--- a/sago/platform_folders.cpp
+++ b/sago/platform_folders.cpp
@@ -103,8 +103,7 @@ std::string win32_utf16_to_utf8(const wchar_t* wstr) {
 	}
 	if (actualSize == 0) {
 		// WideCharToMultiByte return 0 for errors.
-		const std::string errorMsg = "UTF16 to UTF8 failed with error code: " + GetLastError();
-		throw std::runtime_error(errorMsg.c_str());
+		throw std::runtime_error("UTF16 to UTF8 failed with error code: " + std::to_string(GetLastError()));
 	}
 	return res;
 }


### PR DESCRIPTION
Hi, unless I'm mistaken the error message for UTF16 to UTF8 conversion on Windows tries to add a DWORD to a char* and ends up with the wrong message. I explicitly cast the result of GetLastError to string and used C++11's string constructor for std::runtime_error.

Thanks for the great library!