### PR TITLE
Scoped CMake options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,17 @@
 # For target_compile_features
 cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
+
+set(PLATFORMFOLDERS_MAIN_PROJECT OFF)
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  set(PLATFORMFOLDERS_MAIN_PROJECT ON)
+endif()
+
 project(platform_folders VERSION 4.1.0 LANGUAGES CXX)
 
 # BUILD_SHARED_LIBS is off by default, the library will be static by default
 option(PLATFORMFOLDERS_BUILD_SHARED_LIBS "Build platform_folders shared library" ${BUILD_SHARED_LIBS})
+option(PLATFORMFOLDERS_ENABLE_INSTALL "Enable platform_folders INSTALL target" ${PLATFORMFOLDERS_MAIN_PROJECT})
+
 set(PLATFORMFOLDERS_TYPE STATIC)
 if(PLATFORMFOLDERS_BUILD_SHARED_LIBS)
 	set(PLATFORMFOLDERS_TYPE SHARED)
@@ -67,47 +75,49 @@ else()
 	set(_PROJECT_INSTALL_CMAKE_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/platform_folders")
 endif()
 
-# Gives "Make install" esque operations a location to install to...
-# and creates a .cmake file to be exported
-install(TARGETS platform_folders
-	EXPORT "platform_foldersConfig"
-	LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-	ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-	# Tells it where to put the header files
-	PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/sago"
-)
+if(PLATFORMFOLDERS_ENABLE_INSTALL)
+	# Gives "Make install" esque operations a location to install to...
+	# and creates a .cmake file to be exported
+	install(TARGETS platform_folders
+		EXPORT "platform_foldersConfig"
+		LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+		ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+		# Tells it where to put the header files
+		PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/sago"
+	)
 
-# "The install(TARGETS) and install(EXPORT) commands work together to install a target and a file to help import it"
-# Installs a cmake file which external projects can import.
-install(EXPORT "platform_foldersConfig"
-	NAMESPACE sago::
-	DESTINATION "${_PROJECT_INSTALL_CMAKE_DIR}"
-)
+	# "The install(TARGETS) and install(EXPORT) commands work together to install a target and a file to help import it"
+	# Installs a cmake file which external projects can import.
+	install(EXPORT "platform_foldersConfig"
+		NAMESPACE sago::
+		DESTINATION "${_PROJECT_INSTALL_CMAKE_DIR}"
+	)
 
-# "The export command is used to generate a file exporting targets from a project build tree"
-# Creates an import file for external projects which are aware of the build tree.
-# May be useful for cross-compiling
-export(TARGETS platform_folders
-	FILE "platform_folders-exports.cmake"
-)
+	# "The export command is used to generate a file exporting targets from a project build tree"
+	# Creates an import file for external projects which are aware of the build tree.
+	# May be useful for cross-compiling
+	export(TARGETS platform_folders
+		FILE "platform_folders-exports.cmake"
+	)
 
-# For the config and configversion macros
-include(CMakePackageConfigHelpers)
+	# For the config and configversion macros
+	include(CMakePackageConfigHelpers)
 
-# Creates the project's ConfigVersion.cmake file
-# This allows for find_package() to use a version in the call
-write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/platform_foldersConfigVersion.cmake"
-	# This'll require versioning in the project() call
-	VERSION ${CMAKE_PROJECT_VERSION}
-	# Just assuming Semver is followed
-	COMPATIBILITY SameMajorVersion
-)
+	# Creates the project's ConfigVersion.cmake file
+	# This allows for find_package() to use a version in the call
+	write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/platform_foldersConfigVersion.cmake"
+		# This'll require versioning in the project() call
+		VERSION ${CMAKE_PROJECT_VERSION}
+		# Just assuming Semver is followed
+		COMPATIBILITY SameMajorVersion
+	)
 
-# Install the ConfigVersion file, which is located in the build dir
-install(FILES
-		"${CMAKE_CURRENT_BINARY_DIR}/platform_foldersConfigVersion.cmake"
-	DESTINATION "${_PROJECT_INSTALL_CMAKE_DIR}"
-)
+	# Install the ConfigVersion file, which is located in the build dir
+	install(FILES
+			"${CMAKE_CURRENT_BINARY_DIR}/platform_foldersConfigVersion.cmake"
+		DESTINATION "${_PROJECT_INSTALL_CMAKE_DIR}"
+	)
+endif()
 
 # A module for testing the library
 include(CTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ project(platform_folders VERSION 4.1.0 LANGUAGES CXX)
 
 # BUILD_SHARED_LIBS is off by default, the library will be static by default
 option(PLATFORMFOLDERS_BUILD_SHARED_LIBS "Build platform_folders shared library" ${BUILD_SHARED_LIBS})
+option(PLATFORMFOLDERS_BUILD_TESTING "Build platform_folders tests" ${PLATFORMFOLDERS_MAIN_PROJECT})
 option(PLATFORMFOLDERS_ENABLE_INSTALL "Enable platform_folders INSTALL target" ${PLATFORMFOLDERS_MAIN_PROJECT})
 
 set(PLATFORMFOLDERS_TYPE STATIC)
@@ -119,10 +120,8 @@ if(PLATFORMFOLDERS_ENABLE_INSTALL)
 	)
 endif()
 
-# A module for testing the library
-include(CTest)
-# BUILD_TESTING is defined (default ON) in CTest
-if(BUILD_TESTING)
+if(PLATFORMFOLDERS_BUILD_TESTING)
+	enable_testing()
 	add_subdirectory(test)
 	add_executable(platform_folders_sample platform_folders.cpp)
 	target_link_libraries(platform_folders_sample PRIVATE platform_folders)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,14 @@
 cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
 project(platform_folders VERSION 4.1.0 LANGUAGES CXX)
 
-# Since it's off, the library will be static by default
-option(BUILD_SHARED_LIBS "Build shared instead of static." OFF)
+# BUILD_SHARED_LIBS is off by default, the library will be static by default
+option(PLATFORMFOLDERS_BUILD_SHARED_LIBS "Build platform_folders shared library" ${BUILD_SHARED_LIBS})
+set(PLATFORMFOLDERS_TYPE STATIC)
+if(PLATFORMFOLDERS_BUILD_SHARED_LIBS)
+	set(PLATFORMFOLDERS_TYPE SHARED)
+endif()
 
-add_library(platform_folders
+add_library(platform_folders ${PLATFORMFOLDERS_TYPE}
 	sago/platform_folders.cpp
 )
 


### PR DESCRIPTION
Hi thanks for the nice work, I have some minor improvement to share.

## Use Case

I want to use `PlatformFolders` with [`FetchContent`](https://cmake.org/cmake/help/latest/module/FetchContent.html)
I want to be able to disable install, I want test disabled by default. And I want easy control if library should be shared or static

## Solution

I'm following steps from [`CPM`](https://github.com/cpm-cmake/CPM.cmake/wiki/Preparing-projects-for-CPM.cmake).

1. `BUILD_SHARED_LIBS` -> `PLATFORMFOLDERS_BUILD_SHARED_LIBS`
2. `BUILD_TESTING` -> `PLATFORMFOLDERS_BUILD_TESTING`
3. Introduce `PLATFORMFOLDERS_ENABLE_INSTALL` that enable install by default if platform_folders is root cmake project. Behavior can now be overriden by user.